### PR TITLE
Disabled HTTP timeouts on load test tool to fix issue

### DIFF
--- a/victoria_email/load_test.py
+++ b/victoria_email/load_test.py
@@ -73,7 +73,8 @@ async def run_single_test(session: aiohttp.ClientSession, endpoint: str,
     async with session.post(
         load_test_config.mail_send_function_endpoint,
         json=req_body,
-        params={"code": load_test_config.mail_send_function_code}) as resp:
+        params={"code": load_test_config.mail_send_function_code},
+        timeout=aiohttp.ClientTimeout(total=None)) as resp:
         time_now = datetime.now()
         return TestResult(resp.status, await resp.text(), time_now)
 
@@ -91,7 +92,8 @@ async def perform_load_test(frequency: int, endpoint: str, duration: int,
         sender: The email address to send with.
         load_test_config: The config for the load tester.
     """
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(
+            total=None)) as session:
         # between each test we wait for 1/frequency seconds
         wait_interval = 1.0 / frequency
         number_of_intervals = int(frequency * duration)


### PR DESCRIPTION
- Occasionally asyncio timeouts would be observed when running tests, around the part where the POST request is made to the Azure function
- This is due to aiohttp having a default total timeout of five minutes, and when enough tests are being sent the limit of concurrent TCP sockets would be reached - causing a timeout for those async tasks that are still waiting for a handshake to occur
- To fix this, I've simply disabled the timeout